### PR TITLE
CommitmentLimit <= operator

### DIFF
--- a/AutomaticWorkAssignment/Source/PawnConditions/CommitmentLimitPawnCondition.cs
+++ b/AutomaticWorkAssignment/Source/PawnConditions/CommitmentLimitPawnCondition.cs
@@ -15,7 +15,7 @@ namespace Lomzie.AutomaticWorkAssignment.PawnConditions
         public bool IsValid(Pawn pawn, WorkSpecification specification, ResolveWorkRequest request)
         {
             if (pawn != null)
-                return request.WorkManager.GetPawnCommitment(pawn) < Limit;
+                return request.WorkManager.GetPawnCommitment(pawn) <= Limit;
             return false;
         }
     }


### PR DESCRIPTION
It would be more convenient if the CommitmentLimit was less than or equal to.

 I create a condition by telling the algorithm that there should be no pawns that have committed more than 100%, but this condition does not allow them. However, it allows those who have committed exactly 100% or less.