### PR TITLE
build: properly call copy subscript, pass current build configuration

### DIFF
--- a/AutomaticWorkAssignment/Properties/launchSettings.json
+++ b/AutomaticWorkAssignment/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "Run RimWorld": {
       "commandName": "Executable",
       "executablePath": "pwsh",
-      "commandLineArgs": ".\\start.ps1 \"$(SteamAppsPath)\"",
+      "commandLineArgs": ".\\start.ps1 \"$(SteamAppsPath)\" \"$(Configuration)\"",
       "workingDirectory": "$(SolutionDir)"
     }
   }

--- a/copy.ps1
+++ b/copy.ps1
@@ -1,3 +1,7 @@
+param(
+    [Parameter(Position=0,mandatory=$true)][String] $Configuration
+)
+
 Write-Host "Copy files"
-dotnet msbuild -target:CopyModPatch
-dotnet msbuild -target:CopyMod
+dotnet msbuild -property:Configuration=$Configuration -target:CopyMod
+dotnet msbuild -property:Configuration=$Configuration -target:CopyModPatch

--- a/start.ps1
+++ b/start.ps1
@@ -1,19 +1,20 @@
 param(
-    [Parameter(Position=0,mandatory=$true)][String] $SteamAppsPath
+    [Parameter(Position=0,mandatory=$true)][String] $SteamAppsPath,
+    [Parameter(Position=1,mandatory=$true)][String] $Configuration
 )
 
 $PID_FILE='.rw.pid'
 if(Test-Path $PID_FILE -PathType Leaf){
     Write-Host "Kill previous instance of RimWorld"
     $prevPid = Get-Content $PID_FILE
-    $process = Get-Process -Id $prevPid
+    $process = Get-Process -Id $prevPid 2>$null
     if($process && $process.Name -ilike "RimWorld*"){
         Stop-Process $prevPid
     }
     Remove-Item $PID_FILE
 }
 
-. copy.ps1
+. .\copy.ps1 $Configuration
 
 Write-Host "Starting RimWorld"
 $rwProcess = Start-Process "$SteamAppsPath\common\RimWorld\RimWorldWin64.exe" -passthru


### PR DESCRIPTION
Call to `copy.ps1` was invalid. Also, if VS is set up in `Release` configuration, the files were'nt properly copied