### PR TITLE
Added time assignment condition for manage schedule

### DIFF
--- a/AutomaticWorkAssignment/1.5/Defs/PawnConditionDefs.xml
+++ b/AutomaticWorkAssignment/1.5/Defs/PawnConditionDefs.xml
@@ -7,6 +7,12 @@
     <description>Check if pawns skill level is within a given range.</description>
   </Def>
   <Def Class="Lomzie.AutomaticWorkAssignment.Defs.PawnConditionDef">
+    <defName>Lomzie_CompareTimeAssignmentCondition</defName>
+    <settingClass>Lomzie.AutomaticWorkAssignment.PawnConditions.TimeAssignmentCondition</settingClass>
+    <label>compare time assignment</label>
+    <description>Compare the type of activity from pawn's schedule with the specified type of activity.</description>
+  </Def>
+  <Def Class="Lomzie.AutomaticWorkAssignment.Defs.PawnConditionDef">
     <defName>Lomzie_HasPassionCondition</defName>
     <settingClass>Lomzie.AutomaticWorkAssignment.PawnConditions.PassionPawnCondition</settingClass>
     <label>has passion</label>

--- a/AutomaticWorkAssignment/1.5/Languages/English/Keyed/Interface.xml
+++ b/AutomaticWorkAssignment/1.5/Languages/English/Keyed/Interface.xml
@@ -14,6 +14,7 @@
   <AWA.PawnAdd>Add pawn</AWA.PawnAdd>
   <AWA.TraitSelect>Select trait</AWA.TraitSelect>
   <AWA.TraitAdd>Add trait</AWA.TraitAdd>
+  <AWA.TimeAssignmentSelect>Add time assignment</AWA.TimeAssignmentSelect>
   <AWA.ClassSelect>Select class</AWA.ClassSelect>
   <AWA.ClassAdd>Add class</AWA.ClassAdd>
   <AWA.StageSelect>Select stage</AWA.StageSelect>

--- a/AutomaticWorkAssignment/1.6/Defs/PawnConditionDefs.xml
+++ b/AutomaticWorkAssignment/1.6/Defs/PawnConditionDefs.xml
@@ -7,6 +7,13 @@
     <description>Assign to pawns with the given trait.</description>
   </Def>
   <Def Class="Lomzie.AutomaticWorkAssignment.Defs.PawnConditionDef">
+    <defName>Lomzie_TimeAssignmentCondition</defName>
+    <settingClass>Lomzie.AutomaticWorkAssignment.PawnConditions.TimeAssignmentCondition</settingClass>
+    <label>compare time assignment</label>
+    <description>Compare the type of activity from pawn's schedule with the specified type of activity.</description>
+    <category>Misc</category>
+  </Def>
+  <Def Class="Lomzie.AutomaticWorkAssignment.Defs.PawnConditionDef">
     <defName>Lomzie_SkillLevelCondition</defName>
     <settingClass>Lomzie.AutomaticWorkAssignment.PawnConditions.SkillLevelPawnCondition</settingClass>
     <label>skill level</label>

--- a/AutomaticWorkAssignment/1.6/Languages/English/Keyed/Interface.xml
+++ b/AutomaticWorkAssignment/1.6/Languages/English/Keyed/Interface.xml
@@ -16,6 +16,7 @@
   <AWA.PawnAdd>Add pawn</AWA.PawnAdd>
   <AWA.TraitSelect>Select trait</AWA.TraitSelect>
   <AWA.TraitAdd>Add trait</AWA.TraitAdd>
+  <AWA.TimeAssignmentSelect>Add time assignment</AWA.TimeAssignmentSelect>
   <AWA.ClassSelect>Select class</AWA.ClassSelect>
   <AWA.ClassAdd>Add class</AWA.ClassAdd>
   <AWA.StageSelect>Select stage</AWA.StageSelect>

--- a/AutomaticWorkAssignment/Source/AutomaticWorkAssignmentMod.cs
+++ b/AutomaticWorkAssignment/Source/AutomaticWorkAssignmentMod.cs
@@ -149,6 +149,8 @@ namespace Lomzie.AutomaticWorkAssignment
                 (m) => DefDatabase<SkillDef>.AllDefs, x => x.LabelCap, x => x?.SkillDef?.LabelCap ?? "AWA.SkillSelect".Translate(), (c, s) => c.SkillDef = s));
             PawnSettingUIHandlers.AddHandler(new PickerPawnSettingUIHandler<SpecificPawnCondition, Pawn>(
                 (m) => MapWorkManager.GetManager(m).GetAllPawns(), x => x.Name.ToString(), x => x?.Pawn?.Name.ToString() ?? "AWA.PawnSelect".Translate(), (c, s) => c.Pawn = s));
+            PawnSettingUIHandlers.AddHandler(new PickerPawnSettingUIHandler<TimeAssignmentCondition, TimeAssignmentDef>(
+                (m) => DefDatabase<TimeAssignmentDef>.AllDefs, x => x.LabelCap, x => x.TimeAssignmentDef?.LabelCap ?? "AWA.TimeAssignmentSelect".Translate(), (c, s) => c.TimeAssignmentDef = s));
             PawnSettingUIHandlers.AddHandler(new PickerPawnSettingUIHandler<TraitPawnCondition, TraitDef>(
                 (m) => DefDatabase<TraitDef>.AllDefs, x => x.degreeDatas?.FirstOrDefault()?.label ?? x.label, x => x?.TraitDef?.label ?? x.TraitDef?.degreeDatas?.FirstOrDefault()?.label ?? "AWA.TraitSelect".Translate(), (c, s) => c.TraitDef = s));
             PawnSettingUIHandlers.AddHandler(new PickerPawnSettingUIHandler<WeaponClassPawnCondition, WeaponClassDef>(

--- a/AutomaticWorkAssignment/Source/PawnConditions/TimeAssignmentCondition.cs
+++ b/AutomaticWorkAssignment/Source/PawnConditions/TimeAssignmentCondition.cs
@@ -1,0 +1,19 @@
+﻿using Lomzie.AutomaticWorkAssignment.PawnConditions;
+using RimWorld;
+using Verse;
+
+namespace Lomzie.AutomaticWorkAssignment.PawnConditions
+{
+    public class TimeAssignmentCondition : PawnSetting, IPawnCondition
+    {
+        public TimeAssignmentDef TimeAssignmentDef;
+
+        public override void ExposeData()
+        {
+            base.ExposeData();
+            Scribe_Defs.Look(ref TimeAssignmentDef, "timeAssignmentDef");
+        }
+        public bool IsValid(Pawn pawn, WorkSpecification specification, ResolveWorkRequest request)
+            => pawn.timetable.CurrentAssignment == TimeAssignmentDef;
+    }
+}


### PR DESCRIPTION
I have added a new PawnCondition type implementation that compares the current pawn schedule with what is specified in the condition setting. This allows regular updates (every hour) to set zones for pawns, depending on the type of activity in the schedule.

<img width="1786" height="976" alt="image" src="https://github.com/user-attachments/assets/e67b8419-7106-4e7a-92f2-476baaad2196" />
https://skr.sh/vXoEftDooAu

Ideally, in the new addon about events, make events for changing the type of activity, and then perform actions. I can implement this, I've already studied the work of the new addon a bit.

This solution is rather temporary, until the new addon is fully implemented.