### PR TITLE
Added "Ignore commitment" flag

### DIFF
--- a/AutomaticWorkAssignment/1.6/Languages/English/Keyed/Interface.xml
+++ b/AutomaticWorkAssignment/1.6/Languages/English/Keyed/Interface.xml
@@ -119,6 +119,8 @@
   <AWA.LabelInterweavePrioritiesTip>Spread out assignees work over the different priorities?</AWA.LabelInterweavePrioritiesTip>
   <AWA.LabelIncludeSpecialists>Include specialists</AWA.LabelIncludeSpecialists>
   <AWA.LabelIncludeSpecialistsTip>Consider pawns marked as specialists?</AWA.LabelIncludeSpecialistsTip>
+  <AWA.LabelIgnoreCommitment>Ignore commitment</AWA.LabelIgnoreCommitment>
+  <AWA.LabelIgnoreCommitmentTip>Set the value to true if you want to ignore the commitment mechanism.</AWA.LabelIgnoreCommitmentTip>
   <AWA.LabelCountAssigneesFrom>Count assigness from</AWA.LabelCountAssigneesFrom>
   <AWA.LabelCountAssigneesFromTip>Count assignees from other specifications, as being assigned to this.</AWA.LabelCountAssigneesFromTip>
   <AWA.LabelAddWorkSpecification>Add work specification</AWA.LabelAddWorkSpecification>

--- a/AutomaticWorkAssignment/Source/MapWorkManager.cs
+++ b/AutomaticWorkAssignment/Source/MapWorkManager.cs
@@ -324,7 +324,7 @@ namespace Lomzie.AutomaticWorkAssignment
 
                 // Go over each work specification, find best fits, and assign work accordingly.
                 var availablePawns = req.Pawns.Where(x => (current.IncludeSpecialists || !specialists.Contains(x)) && CanBeAssignedTo(x, current));
-                IEnumerable<Pawn>matchesSorted = current.GetApplicableOrMinimalPawnsSorted(availablePawns, req);
+                IEnumerable<Pawn> matchesSorted = current.GetApplicableOrMinimalPawnsSorted(availablePawns, req);
 
                 int currentAssigned = GetCountAssignedTo(current);
                 int targetAssigned = current.GetTargetWorkers(req);
@@ -341,7 +341,11 @@ namespace Lomzie.AutomaticWorkAssignment
                     // Max commitment level increases if no pawns with enough available commitment was found.
                     for (int c = 0; c < maxCommitment; c++)
                     {
-                        Queue<Pawn> commitable = new Queue<Pawn>(availableToAssign.Where(x => GetPawnCommitment(x) < maxTargetCommitment + c));
+                        Queue<Pawn> commitable = new Queue<Pawn>(
+                            current.IsIgnoreCommitment ? 
+                            availableToAssign : 
+                            availableToAssign.Where(x => GetPawnCommitment(x) < maxTargetCommitment + c)
+                        );
 
                         int i = 0;
                         int assigned = 0;
@@ -364,6 +368,11 @@ namespace Lomzie.AutomaticWorkAssignment
                         if (toAssign == 0)
                         {
                             // Completed the for-loop, all assignents have been made, so we can move on.
+                            break;
+                        }
+                        if (current.IsIgnoreCommitment)
+                        {
+                            // We don't use commitment mechanism. We need one iteration to assign pawns.
                             break;
                         }
                     }

--- a/AutomaticWorkAssignment/Source/UI/WorkManagerWindow.cs
+++ b/AutomaticWorkAssignment/Source/UI/WorkManagerWindow.cs
@@ -564,6 +564,10 @@ namespace Lomzie.AutomaticWorkAssignment.UI
             Rect interweaveRect = new Rect(requireCapabilityRect);
             interweaveRect.y += InputSize;
             DrawPrioritySettingsToggle(interweaveRect, ref _currentWorkSpecification.InterweavePriorities, "AWA.LabelInterweavePriorities".Translate(), "AWA.LabelInterweavePrioritiesTip".Translate());
+
+            Rect ignoreCommitmentRect = new Rect(interweaveRect);
+            ignoreCommitmentRect.y += InputSize;
+            DrawPrioritySettingsToggle(ignoreCommitmentRect, ref _currentWorkSpecification.IsIgnoreCommitment, "AWA.LabelIgnoreCommitment".Translate(), "AWA.LabelIgnoreCommitmentTip".Translate());
         }
 
         private void DrawPrioritySettingsToggle(Rect rect, ref bool value, string label, string description)

--- a/AutomaticWorkAssignment/Source/WorkSpecification.cs
+++ b/AutomaticWorkAssignment/Source/WorkSpecification.cs
@@ -21,6 +21,7 @@ namespace Lomzie.AutomaticWorkAssignment
         public bool InterweavePriorities; // Subsequent assignments to pawns will be shifted right.
         public bool IsSpecialist; // Job will prohibit assignments to jobs further down the list.
         public bool IncludeSpecialists = false; // The job tries to be assigned according to the rules, even if the pawn was assigned to the job by a specialist
+        public bool IsIgnoreCommitment = false; // Do not consider commitment when assigning pawns to the working specification. Use ONLY the fitness functions
         public bool IsSuspended;
         public bool EnableAlert = true;
         public float Commitment; // 0 = Occasional, 0.5 = part-time work, 1.0 = full-time work.
@@ -196,6 +197,7 @@ namespace Lomzie.AutomaticWorkAssignment
             Scribe_Values.Look(ref IsCritical, "isCritical");
             Scribe_Values.Look(ref IsSpecialist, "isSpecialist");
             Scribe_Values.Look(ref IncludeSpecialists, "isIgnoreSpecialist");
+            Scribe_Values.Look(ref IsIgnoreCommitment, "isIgnoreCommitment");
             Scribe_Values.Look(ref IsSuspended, "isSuspended");
             Scribe_Values.Look(ref EnableAlert, "enableAlert", true);
             Scribe_Values.Look(ref RequireFullPawnCapability, "requireFullPawnCapability");


### PR DESCRIPTION
I have two pawns:
11 skill
<img width="1280" height="749" alt="image" src="https://github.com/user-attachments/assets/88b3cd5b-9ef5-41e8-a829-cd78e5f5e9fd" />
2 skill
<img width="1280" height="752" alt="image" src="https://github.com/user-attachments/assets/1cbef248-67d3-4967-b801-6f549f0a94f6" />

I want to assign a pawn with 11 skill, ignoring its obligations. Otherwise, a pawn with 2 skills will be put on an irrelevant job. This is necessary for work specifications, which do not assign jobs, but are some kind of boxes with post processors that dress pawns in certain armor and weapons.

<img width="1280" height="752" alt="image" src="https://github.com/user-attachments/assets/f3ba3121-a4c9-419c-969f-b30a7dd5df30" />
<img width="1280" height="753" alt="image" src="https://github.com/user-attachments/assets/b10265f3-c76b-4eed-845f-6dcf36aaa6a8" />
<img width="1280" height="752" alt="image" src="https://github.com/user-attachments/assets/139a0dbf-4860-43b5-a5df-54f8f1538102" />
<img width="1280" height="751" alt="image" src="https://github.com/user-attachments/assets/10efe6a4-e947-44c2-9938-a896f2edfcaf" />
<img width="1280" height="753" alt="image" src="https://github.com/user-attachments/assets/f806422e-8ec4-44a6-b872-9c1d2eef18fa" />
